### PR TITLE
Signal data change via connect_port()

### DIFF
--- a/lv2/lv2plug.in/ns/lv2core/lv2.h
+++ b/lv2/lv2plug.in/ns/lv2core/lv2.h
@@ -116,6 +116,7 @@
 #define LV2_CORE__requiredFeature    LV2_CORE_PREFIX "requiredFeature"     ///< http://lv2plug.in/ns/lv2core#requiredFeature
 #define LV2_CORE__sampleRate         LV2_CORE_PREFIX "sampleRate"          ///< http://lv2plug.in/ns/lv2core#sampleRate
 #define LV2_CORE__scalePoint         LV2_CORE_PREFIX "scalePoint"          ///< http://lv2plug.in/ns/lv2core#scalePoint
+#define LV2_CORE__signalsDataChange  LV2_CORE_PREFIX "signalsDataChange"   ///< http://lv2plug.in/ns/lv2core#signalsDataChange
 #define LV2_CORE__symbol             LV2_CORE_PREFIX "symbol"              ///< http://lv2plug.in/ns/lv2core#symbol
 #define LV2_CORE__toggled            LV2_CORE_PREFIX "toggled"             ///< http://lv2plug.in/ns/lv2core#toggled
 

--- a/lv2/lv2plug.in/ns/lv2core/lv2core.ttl
+++ b/lv2/lv2plug.in/ns/lv2core/lv2core.ttl
@@ -746,6 +746,18 @@ plugin MUST satisfy all of the following:</p>
 <p>Note these rules apply to the connect_port() function as well as run().</p>
 """ .
 
+lv2:signalsDataChange
+	a lv2:Feature ;
+	rdfs:label "signals data change" ;
+	lv2:documentation """
+This feature indicates that the Lv2 host will call connect_port() for the 
+corresponding control input port whenever its data has changed.
+Therefore the Lv2 plugin does not need to compare the current control port data
+with the old one to detect whether the data has changed.
+""" .
+
+be called when ever a 
+
 lv2:PortProperty
 	a rdfs:Class ,
 		owl:Class ;


### PR DESCRIPTION
This PR introduces a new feature which can be provided by the Lv2 host.
When supported by the Lv2 host the Lv2 host has to call connect_port() for each control input port with changed data.

A compare of each control input port can result in heavy memory loads
For example there are 100 Lv2 plugin instances.
Each of them provides 50 controls and each control supports up to 8 channels.
To reduce the latency a period time of 2ms was chosen. Reading of all these control ports will result in a memory read  throughput of 80MB/s (=100 plugins * 50 controls * 8 channels * 4 byte / 2ms). To compare the data at least the old and the current values of the control ports has to be read. Therefore we would end up with a memory read throughput of at least 160MB/s (= 2 * 80MB/s).

When this new feature is supported by the Lv2 host the Lv2 plugin can avoid this compare.

I will also provide the required JALV change when this Lv2 change is accepted.