### PR TITLE
Deploy lv2_util.h also for external lv2 plugins

### DIFF
--- a/wscript
+++ b/wscript
@@ -255,10 +255,12 @@ def build(bld):
             bld.path.ant_glob('lv2/lv2plug.in/ns/extensions/*', dir=True))
 
     # Copy lv2.h to URI-style include path in build directory
-    lv2_h_path = 'lv2/lv2plug.in/ns/lv2core/lv2.h'
-    bld(rule   = link,
-        source = bld.path.find_node(lv2_h_path),
-        target = bld.path.get_bld().make_node(lv2_h_path))
+    lv2_h_paths = ['lv2/lv2plug.in/ns/lv2core/lv2.h',
+                   'lv2/lv2plug.in/ns/lv2core/lv2_util.h']
+    for path in lv2_h_paths:
+        bld(rule   = link,
+            source = bld.path.find_node(path),
+            target = bld.path.get_bld().make_node(path))
 
     # LV2 pkgconfig file
     bld(features     = 'subst',


### PR DESCRIPTION
Without this change the lv2_util header file is not part of the lv2 package nor of the lv2-dev package.
Therefore external Lv2 plugins could not use it.