### PR TITLE
eg-sampler: Fix segfault on old_sample null deref

### DIFF
--- a/plugins/eg-sampler.lv2/sampler.c
+++ b/plugins/eg-sampler.lv2/sampler.c
@@ -220,13 +220,11 @@ work_response(LV2_Handle  instance,
 	                      old_sample };
 	self->schedule->schedule_work(self->schedule->handle, sizeof(msg), &msg);
 
-	if (strcmp(old_sample->path, new_sample->path)) {
-		// Send a notification that we're using a new sample
-		lv2_atom_forge_frame_time(&self->forge, self->frame_offset);
-		write_set_file(&self->forge, &self->uris,
-		               new_sample->path,
-		               new_sample->path_len);
-	}
+	// Send a notification that we're using a new sample
+	lv2_atom_forge_frame_time(&self->forge, self->frame_offset);
+	write_set_file(&self->forge, &self->uris,
+		       new_sample->path,
+		       new_sample->path_len);
 
 	return LV2_WORKER_SUCCESS;
 }


### PR DESCRIPTION
This commit fixes a segmentation fault in the eg-sampler
when a sample is loaded for the first time. Dereferencing
old_sample->path causes the NULL pointer segfault.

Resolved by always simplifying code to always write_set_file,
even if the filename is the same.

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>