### PR TITLE
Add urid:blank feature

### DIFF
--- a/doc/reference.doxygen.in
+++ b/doc/reference.doxygen.in
@@ -881,7 +881,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = @LV2_SRCDIR@
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/lv2/core/meta.ttl
+++ b/lv2/core/meta.ttl
@@ -220,3 +220,7 @@ meta:bmwiedemann
 	foaf:name "Bernhard M. Wiedemann" ;
 	foaf:mbox <bwiedemann@suse.de> .
 
+meta:ventosus
+	a foaf:Person ;
+	foaf:name "Hanspeter Portner" ;
+	foaf:mbox <mailto:dev@open-music-kontrollers.ch> .

--- a/lv2/urid/blank-host-test.c
+++ b/lv2/urid/blank-host-test.c
@@ -1,0 +1,195 @@
+/*
+  Copyright 2019 David Robillard <http://drobilla.net>
+  Copyright 2019 Hanspeter Portner <https://open-music-kontrollers.ch>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef __STDC_NO_THREADS__
+#	include <threads.h>
+#else
+#	include <pthread.h>
+#endif
+
+#include "lv2/core/lv2.h"
+#include "lv2/urid/blank-host.h"
+
+#define MAX_BLANK   0x1000000
+#define MAX_THREADS 12
+#define MAX_IDS     (MAX_BLANK*MAX_THREADS)
+
+static LV2_URID_Blank lv2_urid_blank = {
+	.handle = NULL,
+	.id = lv2_urid_blank_id
+};
+
+static const LV2_Feature lv2_urid_blank_feature = {
+	.URI = LV2_URID__blank,
+	.data = &lv2_urid_blank
+};
+
+static atomic_flag flags [MAX_IDS];
+
+static void *
+run(void *data)
+{
+	LV2_URID_Blank *blank = data;
+
+	int *res = calloc(1, sizeof(int));
+	if(!res)
+	{
+		return NULL;
+	}
+	
+	for(LV2_URID_Blank_ID i = 0, last = 0; i < MAX_BLANK; i++)
+	{
+		const LV2_URID_Blank_ID id = blank->id(blank->handle, 0);
+
+		if(atomic_flag_test_and_set_explicit(&flags[id], memory_order_relaxed))
+		{
+			*res |= 1;
+		}
+
+		last = id;
+	}
+
+	return res;
+}
+
+#ifndef __STDC_NO_THREADS__
+static int
+start(void *data)
+{
+	int *res = run(data);
+	if(!res)
+	{
+		return 1;
+	}
+
+	free(res);
+	return 0;
+}
+#endif
+
+int
+main(void)
+{
+	const LV2_Feature *feat = &lv2_urid_blank_feature;
+	if(!feat)
+	{
+		goto fail;
+	}
+
+	if(strcmp(feat->URI, LV2_URID__blank) != 0)
+	{
+		goto fail;
+	}
+
+	LV2_URID_Blank *blank = feat->data;
+	if(!blank)
+	{
+		goto fail;
+	}
+
+	for(int i = 0; i < MAX_IDS; i++)
+	{
+		atomic_flag_clear_explicit(&flags[i], memory_order_relaxed);
+	}
+
+#ifndef __STDC_NO_THREADS__
+	thrd_t threads [MAX_THREADS];
+#else
+	pthread_t threads [MAX_THREADS];
+#endif
+
+	for(int i = 0; i < MAX_THREADS; i++)
+	{
+#ifndef __STDC_NO_THREADS__
+		if(thrd_create(&threads[i], start, blank) != thrd_success)
+#else
+		if(pthread_create(&threads[i], 0, run, blank) != 0)
+#endif
+		{
+			for(i--; i >= 0; i--)
+			{
+#ifndef __STDC_NO_THREADS__
+				thrd_join(threads[i], NULL);
+#else
+				int *res = NULL;
+
+				pthread_join(threads[i], &res);
+
+				if(res)
+				{
+					free(res);
+				}
+#endif
+			}
+
+			goto fail;
+		}
+	}
+
+	int ret = 0;
+
+	for(int i = 0; i < MAX_THREADS; i++)
+	{
+#ifndef __STDC_NO_THREADS__
+		int res = 0;
+
+		if(thrd_join(threads[i], &res) != thrd_success)
+		{
+			ret |= 1;
+			continue;
+		}
+
+		ret |= res;
+#else
+		int *res = NULL;
+
+		if(pthread_join(threads[i], (void **)&res) != 0)
+		{
+			ret |= 1;
+			continue;
+		}
+
+		if(!res)
+		{
+			ret |= 1;
+			continue;
+		}
+
+		ret |= *res;
+		free(res);
+#endif
+	}
+
+	if(ret != 0)
+	{
+		goto fail;
+	}
+
+	const LV2_URID_Blank_ID id = blank->id(blank->handle, 0);
+	if(id != MAX_IDS)
+	{
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	return 1;
+}

--- a/lv2/urid/blank-host.h
+++ b/lv2/urid/blank-host.h
@@ -1,0 +1,50 @@
+/*
+  Copyright 2019 David Robillard <http://drobilla.net>
+  Copyright 2019 Hanspeter Portner <https://open-music-kontrollers.ch>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef LV2_URID_BLANK_HOST_H
+#define LV2_URID_BLANK_HOST_H
+
+#include <stdatomic.h>
+
+#include "lv2/urid/urid.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (ATOMIC_INT_LOCK_FREE != 2)
+#	error "atomic_uint is not lock-free"
+#endif
+
+/** [lv2-urid-blank-host-example] */
+
+static LV2_URID_Blank_ID
+lv2_urid_blank_id(LV2_URID_Blank_Handle handle __attribute__((unused)),
+	uint32_t flags)
+{
+	static atomic_uint counter = ATOMIC_VAR_INIT(0);
+
+	return atomic_fetch_add_explicit(&counter, 1, memory_order_relaxed);
+}
+
+/** [lv2-urid-blank-host-example] */
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* LV2_URID_BLANK_HOST_H */

--- a/lv2/urid/lv2-urid.doap.ttl
+++ b/lv2/urid/lv2-urid.doap.ttl
@@ -12,6 +12,15 @@
 	doap:developer <http://lv2plug.in/ns/meta#gabrbedd> ;
 	doap:maintainer <http://drobilla.net/drobilla#me> ;
 	doap:release [
+		doap:revision "1.5" ;
+		doap:created "2019-03-30" ;
+		dcs:blame <http://lv2plug.in/ns/meta#ventosus> ;
+		dcs:changeset [
+			dcs:item [
+				rdfs:label "add urid:blank feature."
+			]
+		]
+	] , [
 		doap:revision "1.4" ;
 		doap:created "2012-10-14" ;
 		doap:file-release <http://lv2plug.in/spec/lv2-1.2.0.tar.bz2> ;

--- a/lv2/urid/manifest.ttl
+++ b/lv2/urid/manifest.ttl
@@ -4,5 +4,5 @@
 <http://lv2plug.in/ns/ext/urid>
 	a lv2:Specification ;
 	lv2:minorVersion 1 ;
-	lv2:microVersion 4 ;
+	lv2:microVersion 5 ;
 	rdfs:seeAlso <urid.ttl> .

--- a/lv2/urid/urid.h
+++ b/lv2/urid/urid.h
@@ -1,5 +1,6 @@
 /*
-  Copyright 2008-2016 David Robillard <http://drobilla.net>
+  Copyright 2008-2019 David Robillard <http://drobilla.net>
+  Copyright 2019 Hanspeter Portner <https://open-music-kontrollers.ch>
   Copyright 2011 Gabriel M. Beddingfield <gabrbedd@gmail.com>
 
   Permission to use, copy, modify, and/or distribute this software for any
@@ -32,6 +33,7 @@
 
 #define LV2_URID__map   LV2_URID_PREFIX "map"    ///< http://lv2plug.in/ns/ext/urid#map
 #define LV2_URID__unmap LV2_URID_PREFIX "unmap"  ///< http://lv2plug.in/ns/ext/urid#unmap
+#define LV2_URID__blank LV2_URID_PREFIX "blank"  ///< http://lv2plug.in/ns/ext/urid#blank
 
 #define LV2_URID_MAP_URI   LV2_URID__map    ///< Legacy
 #define LV2_URID_UNMAP_URI LV2_URID__unmap  ///< Legacy
@@ -53,9 +55,19 @@ typedef void* LV2_URID_Map_Handle;
 typedef void* LV2_URID_Unmap_Handle;
 
 /**
+   Opaque pointer to host data for LV2_URID_Blank.
+*/
+typedef void* LV2_URID_Blank_Handle;
+
+/**
    URI mapped to an integer.
 */
 typedef uint32_t LV2_URID;
+
+/**
+   Blank integer ID.
+*/
+typedef uint32_t LV2_URID_Blank_ID;
 
 /**
    URID Map Feature (LV2_URID__map)
@@ -124,6 +136,32 @@ typedef struct _LV2_URID_Unmap {
 	const char* (*unmap)(LV2_URID_Unmap_Handle handle,
 	                     LV2_URID              urid);
 } LV2_URID_Unmap;
+
+/**
+   URID Blank Feature (LV2_URID__blank)
+*/
+typedef struct _LV2_URID_Blank {
+	/**
+	   Opaque pointer to host data.
+
+	   This MUST be passed to id() whenever it is called.
+	   Otherwise, it must not be interpreted in any way.
+	*/
+	LV2_URID_Blank_Handle handle;
+
+	/**
+	   Get a unique unsigned integer identifier.
+
+	   This function MUST be RT-safe, non-blocking, lock-free and wait-free.
+
+	   @param handle MUST be the callback_data member of this struct.
+	   @param flags Currently unused.
+
+		 @par Example host implementation (with C11 atomics):
+		 @snippet lv2/urid/blank-host.h lv2-urid-blank-host-example
+	*/
+	LV2_URID_Blank_ID (*id)(LV2_URID_Blank_Handle handle, uint32_t flags);
+} LV2_URID_Blank;
 
 #ifdef __cplusplus
 }  /* extern "C" */

--- a/lv2/urid/urid.ttl
+++ b/lv2/urid/urid.ttl
@@ -37,3 +37,11 @@ urid:map.  To support this feature, the host must pass an LV2_Feature to
 LV2_Descriptor::instantiate() with URI LV2_URID__unmap and data pointed to
 an instance of LV2_URID_Unmap.</p>
 """ .
+
+urid:blank
+	a lv2:Feature ;
+	lv2:documentation """
+<p>A feature which is used to get unique integer identifiers. To support this
+feature, the host must pass an LV2_Feature to LV2_Descriptor::instantiate() with
+URI LV2_URID__blank and data pointed to an instance of LV2_URID_Blank.</p>
+""" .

--- a/wscript
+++ b/wscript
@@ -219,7 +219,7 @@ def build_spec(bld, path):
         test_cflags    = ['']
         test_linkflags = ['']
         if bld.is_defined('HAVE_GCOV'):
-            test_lib       += ['gcov', 'rt']
+            test_lib       += ['gcov', 'rt', 'pthread']
             test_cflags    += ['--coverage']
             test_linkflags += ['--coverage']
 


### PR DESCRIPTION
Hopefully addresses all of your requests of an earlier mockup [1]

* fixes of a noobs turtle manifest failures
* blank ids are now of type uint32_t
* example host implementation is in its own header with snippet automagically included in doc
* example host implementation has a proper unit test

[1] https://github.com/ventosus/lv2/commit/4112b89a369f0db7bee42432837b1aa506c23204