### PR TITLE
Prototype thread extension

### DIFF
--- a/lv2/core/meta.ttl
+++ b/lv2/core/meta.ttl
@@ -218,6 +218,11 @@ meta:paniq
 	foaf:name "Leonard Ritter" ;
 	foaf:mbox <mailto:paniq@paniq.org> .
 
+meta:x42
+	a foaf:Person ;
+	foaf:name "Robin Gareus" ;
+	foaf:mbox <mailto:robin@gareus.org> .
+
 meta:harry
 	a foaf:Person ;
 	foaf:name "Harry van Haaren" ;

--- a/lv2/thread/lv2-thread.doap.ttl
+++ b/lv2/thread/lv2-thread.doap.ttl
@@ -1,0 +1,23 @@
+@prefix dcs: <http://ontologi.es/doap-changeset#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://lv2plug.in/ns/ext/thread>
+	a doap:Project ;
+	doap:name "LV2 Thread" ;
+	doap:shortdesc "Facilitate plugin background threads." ;
+	doap:created "2019-05-31" ;
+	doap:developer meta:x42 ;
+#TODO:
+#	doap:release [
+#		doap:revision "1.0" ;
+#		doap:created "2019-05-31" ;
+#		doap:file-release <http://lv2plug.in/spec/lv2-1.2.0.tar.bz2> ;
+#		dcs:blame <http://drobilla.net/drobilla#me> ;
+#		dcs:changeset [
+#			dcs:item [
+#				rdfs:label "Initial release."
+#			]
+#		]
+#	]
+	.

--- a/lv2/thread/manifest.ttl
+++ b/lv2/thread/manifest.ttl
@@ -1,0 +1,8 @@
+@prefix lv2:  <http://lv2plug.in/ns/lv2core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<http://lv2plug.in/ns/ext/thread>
+	a lv2:Specification ;
+	lv2:minorVersion 1 ;
+	lv2:microVersion 0 ;
+	rdfs:seeAlso <thread.ttl> .

--- a/lv2/thread/thread.h
+++ b/lv2/thread/thread.h
@@ -1,0 +1,40 @@
+/*
+  Copyright 2012-2016 David Robillard <http://drobilla.net>
+  Copyright 2019 Robin Gareus <robin@gareus.org>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+/**
+   @defgroup thread Thread
+
+   Options to inform plugins about background-thread schedule priority,
+   see <http://lv2plug.in/ns/ext/thread> for details.
+
+   @{
+*/
+
+#ifndef LV2_THREAD_H
+#define LV2_THREAD_H
+
+#define LV2_THREAD_URI    "http://lv2plug.in/ns/ext/thread"  ///< http://lv2plug.in/ns/ext/thread
+#define LV2_THREAD_PREFIX LV2_THREAD_URI "#"                 ///< http://lv2plug.in/ns/ext/thread#
+
+#define LV2_THREAD__schedPolicy    LV2_THREAD_PREFIX "schedPolicy"   ///< http://lv2plug.in/ns/ext/thread#schedPolicy
+#define LV2_THREAD__schedPriority  LV2_THREAD_PREFIX "schedPriority" ///< http://lv2plug.in/ns/ext/thread#schedPriority
+
+#endif  /* LV2_THREAD_H */
+
+/**
+   @}
+*/

--- a/lv2/thread/thread.ttl
+++ b/lv2/thread/thread.ttl
@@ -1,0 +1,54 @@
+@prefix doap:   <http://usefulinc.com/ns/doap#> .
+@prefix foaf:   <http://xmlns.com/foaf/0.1/> .
+@prefix lv2:    <http://lv2plug.in/ns/lv2core#> .
+@prefix opts:   <http://lv2plug.in/ns/ext/options#> .
+@prefix owl:    <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix thread: <http://lv2plug.in/ns/ext/thread#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+
+<http://lv2plug.in/ns/ext/thread>
+	a owl:Ontology ;
+	rdfs:seeAlso <thread.h> ,
+		<lv2-thread.doap.ttl> ;
+	lv2:documentation """
+<p>This extension defines two instantiation options: thread:schedPolicy and
+thread:schedPriority. Plugins that require custom realtime background
+threads should call <code>pthread_setschedparam()</code> with the given
+parameters.</p>
+
+<p>This allows which require background threads to set-up correct realtime
+schedule priorities for those threads, that will not interfere with host
+scheduling.<p>
+
+<p>Hosts should pass values appropriate to not interfere with their
+internal processing. e.g. jack hosts should use
+<code>jack_client_real_time_priority</code> when JACK runs with
+realtime scheduling.<p>
+
+<p>This extension is intended to be used with pthread on Unix systems
+and potentially pthread-w32 on Windows. MacOS plugins that use mach-
+threads can combine <code>pthread_mach_thread_np</code> with time-
+constraints passed via the bufsiz extension when calling
+<code>thread_policy_set</code. The sched policy is applicable as-is
+on all OS.</p>
+""" .
+
+thread:schedPolicy
+	a rdf:Property ,
+		opts:Option ,
+		rdfs:range xsd:nonNegativeInteger;
+	rdfs:label "Schedule policy" ;
+	lv2:documentation """
+<p>The scheduling policy to use.</p>
+""" .
+
+thread:schedPriority
+	a rdf:Property ,
+		opts:Option ,
+		rdfs:range xsd:nonNegativeInteger;
+	rdfs:label "Schedule Priority" ;
+	lv2:documentation """
+<p>The scheduling priority to use.</p>
+""" .


### PR DESCRIPTION
This allows to inform plugins that require background threads
to set-up correct realtime schedule priorities for those threads.