### PR TITLE
eg-sampler (UI): Avoid Crashing When Using Show Interface

### DIFF
--- a/plugins/eg-sampler.lv2/sampler_ui.c
+++ b/plugins/eg-sampler.lv2/sampler_ui.c
@@ -199,6 +199,15 @@ on_canvas_expose(GtkWidget* widget, GdkEventExpose* event, gpointer data)
 	return TRUE;
 }
 
+static void
+hide_window(SamplerUI* ui) {
+	if (ui->window != NULL) {
+		gtk_container_remove(GTK_CONTAINER(ui->window), ui->box);
+		gtk_widget_destroy(ui->window);
+		ui->window = NULL;
+	}
+}
+
 gboolean
 on_window_closed(GtkWidget* widget, GdkEvent* event, gpointer data)
 {
@@ -291,11 +300,14 @@ static void
 cleanup(LV2UI_Handle handle)
 {
 	SamplerUI* ui = (SamplerUI*)handle;
-	gtk_widget_destroy(ui->box);
-	gtk_widget_destroy(ui->play_button);
+	if (ui->window) {
+		hide_window(ui);
+	}
 	gtk_widget_destroy(ui->canvas);
-	gtk_widget_destroy(ui->button_box);
+	gtk_widget_destroy(ui->play_button);
 	gtk_widget_destroy(ui->file_button);
+	gtk_widget_destroy(ui->button_box);
+	gtk_widget_destroy(ui->box);
 	free(ui);
 }
 
@@ -369,13 +381,9 @@ static int
 ui_hide(LV2UI_Handle handle)
 {
 	SamplerUI* ui = (SamplerUI*)handle;
-
-	if (ui->window != NULL) {
-		gtk_container_remove(GTK_CONTAINER(ui->window), ui->box);
-		gtk_widget_destroy(ui->window);
-		ui->window = NULL;
+	if (ui->window) {
+		hide_window(ui);
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
These changes avoid double deleting widgets as a result of Gtk auto free'ing when children are destroyed and/or removed.  I also added some logic so that `gtk_init` is only called once, and switched to `gtk_main_iteration_do`, so that it won't block the UI thread.

I'm currently working on implementing LV2 show/hide with a Mac, and eg-sampler was a good test case since it implements show interface.
